### PR TITLE
Rework attributes handling

### DIFF
--- a/src/Myriad.Core/Types.fs
+++ b/src/Myriad.Core/Types.fs
@@ -3,11 +3,6 @@ namespace Myriad.Core
 open System
 open FSharp.Compiler.Ast
 
-type MyriadGenerateAttribute(generator: string) =
-    inherit Attribute()
-
-    member __.Generator = generator
-
 type MyriadGeneratorAttribute(name: string) =
     inherit Attribute()
 

--- a/src/Myriad.Plugins/Attribute.fs
+++ b/src/Myriad.Plugins/Attribute.fs
@@ -1,0 +1,59 @@
+namespace Myriad.Plugins
+
+open System
+open FSharp.Compiler.Ast
+open Myriad.Core
+
+
+type Plugin =
+    | Fields = 1
+    //PotentiallyAddOtherBuiltInAttributes
+
+
+
+///Inspired by ppx_deriving - `[@@deriving show, eq]`
+type DerivingAttribute(plugins: Plugin []) =
+    inherit Attribute()
+
+    member __.Plugins = plugins
+
+module Attributes =
+    let mapNameToPlugin str =
+        match str with
+        | "Plugin.Fields" -> Some Plugin.Fields
+        | _ -> None
+
+    let getPluginsOnTypeDefinition (td: SynTypeDefn) =
+        let rec getIdent (se: SynExpr) =
+            match se with
+            //Single plugin
+            | SynExpr.LongIdent(_,ld,_,_) ->
+                ld.Lid
+                |> List.map (fun n -> n.idText)
+                |> String.concat "."
+                |> mapNameToPlugin
+                |> Option.map List.singleton
+                |> Option.defaultValue []
+            //Multiple plugins
+            | SynExpr.Sequential(_,true,e1,e2,_) ->
+                [
+                    yield! getIdent e1
+                    yield! getIdent e2
+                ]
+            | _ -> []
+
+
+        td
+        |> Ast.getAttribute<DerivingAttribute>
+        |> Option.bind (fun n ->
+            match n.ArgExpr with
+            | SynExpr.Paren(SynExpr.ArrayOrListOfSeqExpr(true,SynExpr.CompExpr(true,_,expr ,_),_), _,_,_) ->
+                Some (getIdent expr)
+            | _ ->
+                None)
+
+    let checkIfPluginUsed (plugin: Plugin) (td: SynTypeDefn) =
+        match getPluginsOnTypeDefinition td with
+        | None -> false
+        | Some allPlugins ->
+            allPlugins |> List.exists ((=) plugin)

--- a/src/Myriad.Plugins/Attribute.fs
+++ b/src/Myriad.Plugins/Attribute.fs
@@ -1,59 +1,9 @@
 namespace Myriad.Plugins
 
 open System
-open FSharp.Compiler.Ast
-open Myriad.Core
 
 
-type Plugin =
-    | Fields = 1
-    //PotentiallyAddOtherBuiltInAttributes
-
-
-
-///Inspired by ppx_deriving - `[@@deriving show, eq]`
-type DerivingAttribute(plugins: Plugin []) =
-    inherit Attribute()
-
-    member __.Plugins = plugins
-
-module Attributes =
-    let mapNameToPlugin str =
-        match str with
-        | "Plugin.Fields" -> Some Plugin.Fields
-        | _ -> None
-
-    let getPluginsOnTypeDefinition (td: SynTypeDefn) =
-        let rec getIdent (se: SynExpr) =
-            match se with
-            //Single plugin
-            | SynExpr.LongIdent(_,ld,_,_) ->
-                ld.Lid
-                |> List.map (fun n -> n.idText)
-                |> String.concat "."
-                |> mapNameToPlugin
-                |> Option.map List.singleton
-                |> Option.defaultValue []
-            //Multiple plugins
-            | SynExpr.Sequential(_,true,e1,e2,_) ->
-                [
-                    yield! getIdent e1
-                    yield! getIdent e2
-                ]
-            | _ -> []
-
-
-        td
-        |> Ast.getAttribute<DerivingAttribute>
-        |> Option.bind (fun n ->
-            match n.ArgExpr with
-            | SynExpr.Paren(SynExpr.ArrayOrListOfSeqExpr(true,SynExpr.CompExpr(true,_,expr ,_),_), _,_,_) ->
-                Some (getIdent expr)
-            | _ ->
-                None)
-
-    let checkIfPluginUsed (plugin: Plugin) (td: SynTypeDefn) =
-        match getPluginsOnTypeDefinition td with
-        | None -> false
-        | Some allPlugins ->
-            allPlugins |> List.exists ((=) plugin)
+[<RequireQualifiedAccess>]
+module Generator =
+    type FieldsAttribute() =
+        inherit Attribute()

--- a/src/Myriad.Plugins/FieldsGenerator.fs
+++ b/src/Myriad.Plugins/FieldsGenerator.fs
@@ -103,7 +103,7 @@ type FieldsGenerator() =
                 namespaceAndrecords
                 |> List.collect (fun (ns, records) ->
                                     records
-                                    |> List.filter (Ast.hasAttribute "fields")
+                                    |> List.filter (Attributes.checkIfPluginUsed Plugin.Fields)
                                     |> List.map (Create.createRecordModule ns))
 
             let namespaceOrModule =

--- a/src/Myriad.Plugins/FieldsGenerator.fs
+++ b/src/Myriad.Plugins/FieldsGenerator.fs
@@ -103,7 +103,7 @@ type FieldsGenerator() =
                 namespaceAndrecords
                 |> List.collect (fun (ns, records) ->
                                     records
-                                    |> List.filter (Attributes.checkIfPluginUsed Plugin.Fields)
+                                    |> List.filter (Ast.hasAttribute<Generator.FieldsAttribute>)
                                     |> List.map (Create.createRecordModule ns))
 
             let namespaceOrModule =

--- a/src/Myriad.Plugins/Myriad.Plugins.fsproj
+++ b/src/Myriad.Plugins/Myriad.Plugins.fsproj
@@ -8,6 +8,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attribute.fs" />
     <Compile Include="FieldsGenerator.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Myriad.IntegrationPluginTests/Input.fs
+++ b/test/Myriad.IntegrationPluginTests/Input.fs
@@ -2,6 +2,6 @@
 
 open Myriad.Plugins
 
-[<Deriving([|Plugin.Fields |]) >]
+[<Generator.Fields>]
 type Test1 = { one: int; two: string; three: float; four: float32 }
 type Test2 = { one: Test1; two: string }

--- a/test/Myriad.IntegrationPluginTests/Input.fs
+++ b/test/Myriad.IntegrationPluginTests/Input.fs
@@ -1,5 +1,7 @@
 ﻿namespace Example
 
-[<Myriad.Core.MyriadGenerator("fields")>]
+open Myriad.Plugins
+
+[<Deriving([|Plugin.Fields |]) >]
 type Test1 = { one: int; two: string; three: float; four: float32 }
 type Test2 = { one: Test1; two: string }

--- a/test/Myriad.IntegrationPluginTests/Myriad.IntegrationPluginTests.fsproj
+++ b/test/Myriad.IntegrationPluginTests/Myriad.IntegrationPluginTests.fsproj
@@ -22,7 +22,7 @@
     <Compile Include="Tests.fs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../src/Myriad.Core/Myriad.Core.fsproj" PrivateAssets="All" />
+    <ProjectReference Include="../../src/Myriad.Plugins/Myriad.Plugins.fsproj" PrivateAssets="All" />
     <ProjectReference Include="../Myriad.Plugins.Example1/Myriad.Plugins.Example1.fsproj" PrivateAssets="All" />
   </ItemGroup>
 

--- a/test/Myriad.IntegrationPluginTests/Tests.fs
+++ b/test/Myriad.IntegrationPluginTests/Tests.fs
@@ -2,6 +2,7 @@ module Tests
 
 open System
 open Xunit
+open Example
 
 [<Fact>]
 let ``Test namespace generated`` () =
@@ -10,3 +11,25 @@ let ``Test namespace generated`` () =
 [<Fact>]
 let ``Test2 namespace generated`` () =
     Assert.Equal(42, Test2.example1.fourtyTwo)
+
+[<Fact>]
+let ``Test1 create Test`` () =
+    let t = Test.Test1.create 1 "2" 3. (float32 4)
+    Assert.Equal({Test1.one = 1; two = "2"; three = 3.; four = float32 4 }, t)
+
+[<Fact>]
+let ``Test2 create Test`` () =
+    let t = Test2.Test1.create 1 "2" 3. (float32 4)
+    Assert.Equal({Test1.one = 1; two = "2"; three = 3.; four = float32 4 }, t)
+
+[<Fact>]
+let ``Test1 accessor Test`` () =
+    let t = Test.Test1.create 1 "2" 3. (float32 4)
+    let z = Test.Test1.one t
+    Assert.Equal(1, z)
+
+[<Fact>]
+let ``Test2 accessor Test`` () =
+    let t = Test2.Test1.create 1 "2" 3. (float32 4)
+    let z = Test2.Test1.one t
+    Assert.Equal(1, z)


### PR DESCRIPTION
This reworks how attributes are handled in built-in `Plugins` project.

Using `[<Deriving([|Plugin.Fields |]) >]` inspired by `ppx_deriving` 