### PR TITLE
Add generator for DU helpers

### DIFF
--- a/src/Myriad.Core/Ast.fs
+++ b/src/Myriad.Core/Ast.fs
@@ -68,15 +68,27 @@ module Ast =
         | SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.Record _, _) -> true
         | _ -> false
 
-    let extractRecords (ast: ParsedInput) =
-        let records =
-            let types = extractTypeDefn ast
-            let onlyRecords =
-                types
-                |> List.map (fun (ns, types) -> ns, types |> List.filter isRecord )
-            onlyRecords
+    let isDu (TypeDefn(_componentInfo, typeDefRepr, _memberDefs, _)) =
+        match typeDefRepr with
+        | SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.Union _, _) -> true
+        | _ -> false
 
-        records
+
+    let extractRecords (ast: ParsedInput) =
+        let types = extractTypeDefn ast
+        let onlyRecords =
+            types
+            |> List.map (fun (ns, types) -> ns, types |> List.filter isRecord )
+        onlyRecords
+
+
+
+    let extractDU (ast: ParsedInput) =
+        let types = extractTypeDefn ast
+        let onlyDus =
+            types
+            |> List.map (fun (ns, types) -> ns, types |> List.filter isDu )
+        onlyDus
 
     let hasAttributeWithName<'a> (attributeName: string) (TypeDefn(ComponentInfo(attributes, _typeParams, _constraints, _recordIdent, _doc, _preferPostfix, _access, _), _typeDefRepr, _memberDefs, _))  =
         attributes

--- a/src/Myriad.Plugins/Attribute.fs
+++ b/src/Myriad.Plugins/Attribute.fs
@@ -7,3 +7,6 @@ open System
 module Generator =
     type FieldsAttribute() =
         inherit Attribute()
+
+    type DuCasesAttribute() =
+        inherit Attribute()

--- a/src/Myriad.Plugins/DUCasesGenerator.fs
+++ b/src/Myriad.Plugins/DUCasesGenerator.fs
@@ -1,0 +1,130 @@
+namespace Myriad.Plugins
+
+open System
+open FSharp.Compiler.Ast
+open FsAst
+open Myriad.Core
+
+module internal CreateDUModule =
+    open FSharp.Compiler.Range
+
+    let createToString (parent: LongIdent) (cases: SynUnionCases) =
+        let varIdent = LongIdentWithDots.CreateString "toString"
+
+        let duType =
+            LongIdentWithDots.Create (parent |> List.map (fun i -> i.idText))
+            |> SynType.CreateLongIdent
+
+        let pattern =
+            let ident = Ident("currency", range.Zero)
+            let name = SynPatRcd.CreateNamed(ident, SynPatRcd.CreateWild)
+            let args = SynPatRcd.CreateTyped(name, duType) |> SynPatRcd.CreateParen
+            SynPatRcd.CreateLongIdent(varIdent, [args])
+
+        let expr =
+            let matches =
+                cases
+                |> List.map (fun c ->
+                    let case = c.ToRcd
+                    let indent = LongIdentWithDots.CreateString (case.Id.idText)
+                    let p = SynPatRcd.CreateLongIdent(indent, [])
+                    let rhs =
+                       SynExpr.Const(SynConst.CreateString case.Id.idText, range.Zero)
+                    SynMatchClause.Clause(p.FromRcd, None, rhs, range.Zero, SequencePointInfoForTarget.SequencePointAtTarget )
+                )
+            let matchOn =
+                let ident = LongIdentWithDots.CreateString "currency"
+                SynExpr.CreateLongIdent(false, ident, None)
+
+            SynExpr.Match(SequencePointInfoForBinding.NoSequencePointAtLetBinding, matchOn, matches, range.Zero)
+
+        let returnTypeInfo = SynBindingReturnInfoRcd.Create duType
+        SynModuleDecl.CreateLet [{SynBindingRcd.Let with Pattern = pattern; Expr = expr; ReturnInfo = Some returnTypeInfo }]
+
+    let createFromString (parent: LongIdent) (cases: SynUnionCases) =
+        let varIdent = LongIdentWithDots.CreateString "fromString"
+
+        let duType =
+            LongIdentWithDots.Create (parent |> List.map (fun i -> i.idText))
+            |> SynType.CreateLongIdent
+
+        let inputType =
+            LongIdentWithDots.CreateString "string"
+            |> SynType.CreateLongIdent
+
+        let pattern =
+            let ident = Ident("currencyString", range.Zero)
+            let name = SynPatRcd.CreateNamed(ident, SynPatRcd.CreateWild)
+            let args = SynPatRcd.CreateTyped(name, inputType) |> SynPatRcd.CreateParen
+            SynPatRcd.CreateLongIdent(varIdent, [args])
+
+        let expr =
+            let matches =
+                cases
+                |> List.map (fun c ->
+                    let case = c.ToRcd
+                    let rcd = {SynPatConstRcd.Const = SynConst.CreateString case.Id.idText; Range = range.Zero }
+                    let p = SynPatRcd.Const (rcd)
+                    let rhs =
+                        let f = SynExpr.Ident (Ident("Some", range.Zero))
+                        let x = SynExpr.Ident (Ident(case.Id.idText, range.Zero))
+                        SynExpr.App(ExprAtomicFlag.NonAtomic, false, f, x, range.Zero)
+                    SynMatchClause.Clause(p.FromRcd, None, rhs, range.Zero, SequencePointInfoForTarget.SequencePointAtTarget )
+                )
+            let wildCase =
+                let rhs = SynExpr.Ident (Ident("None", range.Zero))
+                SynMatchClause.Clause(SynPat.Wild (range.Zero), None, rhs, range.Zero, SequencePointInfoForTarget.SequencePointAtTarget)
+
+            let matchOn =
+                let ident = LongIdentWithDots.CreateString "currencyString"
+                SynExpr.CreateLongIdent(false, ident, None)
+
+            SynExpr.Match(SequencePointInfoForBinding.NoSequencePointAtLetBinding, matchOn, [yield! matches; wildCase], range.Zero)
+
+        let returnTypeInfo = SynBindingReturnInfoRcd.Create duType
+        SynModuleDecl.CreateLet [{SynBindingRcd.Let with Pattern = pattern; Expr = expr; ReturnInfo = Some returnTypeInfo }]
+
+
+    let createDuModule (moduleOrNamespace: SynModuleOrNamespace) (typeDefn: SynTypeDefn) =
+        let (TypeDefn(synComponentInfo, synTypeDefnRepr, _members, _range)) = typeDefn
+        let (SynModuleOrNamespace(namespaceId, _isRecursive, _isModule, _moduleDecls, _preXmlDoc, _attributes, _access, _)) = moduleOrNamespace
+        let (ComponentInfo(_attributes, _typeParams, _constraints, recordId, _doc, _preferPostfix, _access, _range)) = synComponentInfo
+        match synTypeDefnRepr with
+        | SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.Union(_accessibility, cases, _recordRange), _range) ->
+
+            let openParent = SynModuleDecl.CreateOpen (LongIdentWithDots.Create (namespaceId |> List.map (fun ident -> ident.idText)))
+
+            let toString = createToString recordId cases
+            let fromString = createFromString recordId cases
+
+            let declarations = [
+                openParent
+                toString
+                fromString ]
+
+            let info = SynComponentInfoRcd.Create recordId
+            SynModuleDecl.CreateNestedModule(info, declarations)
+        | _ -> failwithf "Not a record type"
+
+
+
+[<MyriadGenerator("DUs")>]
+type DUCasesGenerator() =
+
+    interface IMyriadGenerator with
+        member __.Generate(namespace', ast: ParsedInput) =
+            let namespaceAndrecords = Ast.extractDU ast
+            let modules =
+                namespaceAndrecords
+                |> List.collect (fun (ns, dus) ->
+                                    dus
+                                    |> List.filter (Ast.hasAttribute<Generator.DuCasesAttribute>)
+                                    |> List.map (CreateDUModule.createDuModule ns))
+
+            let namespaceOrModule =
+                {SynModuleOrNamespaceRcd.CreateNamespace(Ident.CreateLong namespace')
+                    with
+                        IsRecursive = true
+                        Declarations = modules }
+
+            namespaceOrModule

--- a/src/Myriad.Plugins/DUCasesGenerator.fs
+++ b/src/Myriad.Plugins/DUCasesGenerator.fs
@@ -85,9 +85,8 @@ module internal CreateDUModule =
         SynModuleDecl.CreateLet [{SynBindingRcd.Let with Pattern = pattern; Expr = expr; ReturnInfo = Some returnTypeInfo }]
 
 
-    let createDuModule (moduleOrNamespace: SynModuleOrNamespace) (typeDefn: SynTypeDefn) =
+    let createDuModule (namespaceId: LongIdent) (typeDefn: SynTypeDefn) =
         let (TypeDefn(synComponentInfo, synTypeDefnRepr, _members, _range)) = typeDefn
-        let (SynModuleOrNamespace(namespaceId, _isRecursive, _isModule, _moduleDecls, _preXmlDoc, _attributes, _access, _)) = moduleOrNamespace
         let (ComponentInfo(_attributes, _typeParams, _constraints, recordId, _doc, _preferPostfix, _access, _range)) = synComponentInfo
         match synTypeDefnRepr with
         | SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.Union(_accessibility, cases, _recordRange), _range) ->

--- a/src/Myriad.Plugins/Myriad.Plugins.fsproj
+++ b/src/Myriad.Plugins/Myriad.Plugins.fsproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <Compile Include="Attribute.fs" />
     <Compile Include="FieldsGenerator.fs" />
+    <Compile Include="DUCasesGenerator.fs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="build\Myriad.Plugins.props">

--- a/test/Myriad.IntegrationPluginTests/Input.fs
+++ b/test/Myriad.IntegrationPluginTests/Input.fs
@@ -5,3 +5,10 @@ open Myriad.Plugins
 [<Generator.Fields>]
 type Test1 = { one: int; two: string; three: float; four: float32 }
 type Test2 = { one: Test1; two: string }
+
+[<Generator.DuCases>]
+type Currency =
+    | CAD
+    | PLN
+    | EUR
+    | USD

--- a/test/Myriad.IntegrationPluginTests/Input.fs
+++ b/test/Myriad.IntegrationPluginTests/Input.fs
@@ -12,3 +12,4 @@ type Currency =
     | PLN
     | EUR
     | USD
+    | Custom of string


### PR DESCRIPTION
This adds a new generator for the built-in plugin that can generate a bunch of helpers for DUs:

* `toString`
* `fromString`
* `toTag`
* whole set of `is...` for each case

For sample DU:

```
[<Generator.DuCases>]
type Currency =
    | CAD
    | PLN
    | EUR
    | USD
    | Custom of string
```

it generates the following module:

```
module Currency =
    open Example

    let toString (x: Currency) =
        match x with
        | CAD -> "CAD"
        | PLN -> "PLN"
        | EUR -> "EUR"
        | USD -> "USD"
        | Custom _ -> "Custom"

    let fromString (x: string) =
        match x with
        | "CAD" -> Some CAD
        | "PLN" -> Some PLN
        | "EUR" -> Some EUR
        | "USD" -> Some USD
        | _ -> None

    let toTag (x: Currency) =
        match x with
        | CAD -> 0
        | PLN -> 1
        | EUR -> 2
        | USD -> 3
        | Custom _ -> 4

    let isCAD (x: Currency) =
        match x with
        | CAD -> true
        | _ -> false

    let isPLN (x: Currency) =
        match x with
        | PLN -> true
        | _ -> false

    let isEUR (x: Currency) =
        match x with
        | EUR -> true
        | _ -> false

    let isUSD (x: Currency) =
        match x with
        | USD -> true
        | _ -> false

    let isCustom (x: Currency) =
        match x with
        | Custom _ -> true
        | _ -> false
```