### PR TITLE
Changes to help debugging of custom generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ To consume your own plugins that aren't part of the default set included in the 
 </ItemGroup>
 ```
 
+## Debugging
+
+To debug Myriad, you can use the following two command line options:
+
+* `--verbose` - write diagnostic logs out to standard out
+* `--wait-for-debugger` - causes myriad to wait for a debugger to attach to the myriad process
+
+These can be triggered from msbuild by the `<MyriadSdkVerboseOutput>true</MyriadSdkVerboseOutput>` and `<MyriadSdkWaitForDebugger>true</MyriadSdkWaitForDebugger>` properties, respectively.
+
 ## Nuget
 The nuget package for Myriad can be found here:
 [Nuget package](https://www.nuget.org/packages/myriad/)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The full fsproj is detail below:
 
 ## Plugins
 
-Plugins for Myriad are supplied by simply including the nuget package in your project, the nuget infrastructure supplies the necessary MSBuild props and targets so that the plugin is used my Myriad automatically.  Further details for building plugins will follow but following the source for the fields plugin can be used as reference until I write further documentation.
+Plugins for Myriad are supplied by simply including the nuget package in your project, the nuget infrastructure supplies the necessary MSBuild props and targets so that the plugin is used my Myriad automatically.  Following the source for the fields plugin can be used as reference until more details about authoring plugins is created.
 
 ### Using your own Plugins
 
@@ -120,6 +120,26 @@ To consume your own plugins that aren't part of the default set included in the 
 ```xml
 <ItemGroup>
     <MyriadSdkGenerator Include="<path to plugin dll>" />
+</ItemGroup>
+```
+
+For example, if you had a project layout like this:
+
+```
+\src
+-\GeneratorLib
+ - Generator.fs
+ - Generator.fsproj
+-\GeneratorTests
+ - Tests.fs
+ - GeneratorTests.fsproj
+```
+
+The matching element for the tests fsproj would be something like
+
+```
+<ItemGroup>
+    <MyriadSdkGenerator Include="$(MSBuildThisFileDirectory)/../GeneratorLib/bin/$(Configuration)/$(TargetFramework)/GeneratorLib.dll" />
 </ItemGroup>
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ Plugins for Myriad are supplied by simply including the nuget package in your pr
 To consume your own plugins that aren't part of the default set included in the `Myriad.Plugins` package, you must register them with Myriad. The way to do this is by passing in the `--plugin <path to dll>` command-line argument. For MSBuild, this can be done by adding to the `MyriadSdkGenerator` property like so:
 
 ```xml
-<PropertyGroup>
+<ItemGroup>
     <MyriadSdkGenerator Include="<path to plugin dll>" />
-</PropertyGroup>
+</ItemGroup>
 ```
 
 ## Nuget

--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ The full fsproj is detail below:
 
 Plugins for Myriad are supplied by simply including the nuget package in your project, the nuget infrastructure supplies the necessary MSBuild props and targets so that the plugin is used my Myriad automatically.  Further details for building plugins will follow but following the source for the fields plugin can be used as reference until I write further documentation.
 
+### Using your own Plugins
+
+To consume your own plugins that aren't part of the default set included in the `Myriad.Plugins` package, you must register them with Myriad. The way to do this is by passing in the `--plugin <path to dll>` command-line argument. For MSBuild, this can be done by adding to the `MyriadSdkGenerator` property like so:
+
+```xml
+<PropertyGroup>
+    <MyriadSdkGenerator Include="<path to plugin dll>" />
+</PropertyGroup>
+```
 
 ## Nuget
 The nuget package for Myriad can be found here:

--- a/src/Myriad.Core/Myriad.Core.fsproj
+++ b/src/Myriad.Core/Myriad.Core.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Description>Core Myriad library used for developing plugins</Description>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Types.fs" />

--- a/src/Myriad.Plugins/Myriad.Plugins.fsproj
+++ b/src/Myriad.Plugins/Myriad.Plugins.fsproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Description>Set of built-in Myriad plugins</Description>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Myriad.Core\Myriad.Core.fsproj">

--- a/src/Myriad.Sdk/build/Myriad.Sdk.targets
+++ b/src/Myriad.Sdk/build/Myriad.Sdk.targets
@@ -62,6 +62,7 @@
             <MyriadSdk_Args Include='--outputfile "$(_MyriadSdk_OutputFileName)"' />
             <MyriadSdk_Args Include='--namespace "$(_MyriadSdk_Namespace)"' />
             <MyriadSdk_Args Include='--wait-for-debugger' Condition=" '$(MyriadSdkWaitForDebugger)' == 'true' " />
+            <MyriadSdk_Args Include='--verbose' Condition=" '$(MyriadSdkVerboseOutput)' == 'true' " />
             <MyriadSdk_Args Include='--plugin %(MyriadSdkGenerator.FullPath)' Condition=" '@(MyriadSdkGenerator)' != '' "/>
         </ItemGroup>
 

--- a/src/Myriad/Myriad.fsproj
+++ b/src/Myriad/Myriad.fsproj
@@ -5,6 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>myriad</ToolCommandName>
     <Description>Myriad CLI tool</Description>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />


### PR DESCRIPTION
This MR does two things:
* make debug logging usable by people that aren't compiling myriad via a new CLI flag (`--verbose`) and associated msbuild property
* embeds PDBs so that debugging while attached there is useful information for external users.