### PR TITLE
Generation of lenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Myriad is a code generator, put plainly it takes an abstract syntax tree from a 
 
 Myriad can be used from either an MSBuild extension or from its CLI tool.
 
-The idea behind Myriad is to un-complicate, as far as possible, the ability to generate and do meta-programming in F#.  By meta-programming in F# I mean generating actual F# code like discriminated unions and records, not just IL output.
+The idea behind Myriad is to un-complicate, as far as possible, the ability to generate and do meta-programming in F#. By meta-programming in F# I mean generating actual F# code like discriminated unions and records, not just IL output.
 
-Myriad is an evolution of the ideas I developed while working with F#'s type providers and other meta-programming functionality like quotations and AST manipulation.  Myriad aims to make it easy to extend the compiler via Myriad plugins rather than modifying or adjusting Type Providers and other F# improvement that would be a long time to be developed and released.  The idea is you write a Myriad plugin that works on a fragment of AST input, and the plugin supplies AST output with the final form being source code that is built into your project.  Thus the compiler can optimise and tooling can operate effectively too.
+Myriad is an evolution of the ideas I developed while working with F#'s type providers and other meta-programming functionality like quotations and AST manipulation. Myriad aims to make it easy to extend the compiler via Myriad plugins rather than modifying or adjusting Type Providers and other F# improvement that would be a long time to be developed and released.  The idea is you write a Myriad plugin that works on a fragment of AST input, and the plugin supplies AST output with the final form being source code that is built into your project.  Thus the compiler can optimise and tooling can operate effectively too.
 
 ![Build](https://github.com/MoiraeSoftware/myriad/workflows/Build/badge.svg)
 
@@ -46,7 +46,7 @@ type Test1 = { one: int; two: string; three: float; four: float32 }
 type Test2 = { one: Test1; two: string }
 ```
 
-An attribute is used by the plugin so that the code generator plugin knows which parts of the input AST are to be used by the plugin.  If you had several records and you only want the fields plugin to operate on `Test1` then the attrivute would be used like in the example about to only apply `Generator.Fields` to `Test1`.  Note, if you wanted a plugin that just needs the whole input AST then there is no need to provide an input.  Myriad aims to be a library rather than a full framework that ties you to the mechanism used to input and generate code.
+An attribute is used by the plugin so that the code generator plugin knows which parts of the input AST are to be used by the plugin.  If you had several records and you only want the fields plugin to operate on `Test1` then the attribute would be used like in the example about to only apply `Generator.Fields` to `Test1`.  Note, if you wanted a plugin that just needs the whole input AST then there is no need to provide an input.  Myriad aims to be a library rather than a full framework that ties you to the mechanism used to input and generate code.
 
 The fields plugin in this example will generate the following code at prebuild time and compile the code into your assembly:
 ```fsharp
@@ -111,7 +111,7 @@ The full fsproj is detail below:
 
 ## Plugins
 
-Plugins for Myriad are supplied by simply including the nuget package in your project, the nuget infrastructure supplies the necessary MSBuild props and targets so that the plugin is used by Myriad automatically.  Following the source for the fields plugin can be used as reference until more details about authoring plugins is created.
+Plugins for Myriad are supplied by simply including the nuget package in your project, the nuget infrastructure supplies the necessary MSBuild props and targets so that the plugin is used by Myriad automatically. Following the source for the fields plugin can be used as reference until more details about authoring plugins is created.
 
 ### Using external Plugins
 
@@ -178,14 +178,14 @@ In your testing `fsproj` you would add the following to allow the plugin to be u
 
 To debug Myriad, you can use the following two command line options:
 
-* `--verbose` - write diagnostic logs out to standard out
-* `--wait-for-debugger` - causes myriad to wait for a debugger to attach to the myriad process
+* `--verbose` — write diagnostic logs out to standard out
+* `--wait-for-debugger` — causes Myriad to wait for a debugger to attach to the Myriad process
 
 These can be triggered from msbuild by the `<MyriadSdkVerboseOutput>true</MyriadSdkVerboseOutput>` and `<MyriadSdkWaitForDebugger>true</MyriadSdkWaitForDebugger>` properties, respectively.
 
 ## Nuget
 The nuget package for Myriad can be found here:
-[Nuget package](https://www.nuget.org/packages/myriad/)
+[Nuget package](https://www.nuget.org/packages/myriad/).
 
 ## How to build and test
 

--- a/src/Myriad.Core/Ast.fs
+++ b/src/Myriad.Core/Ast.fs
@@ -14,7 +14,6 @@ module Ast =
         let checker = FSharpChecker.Create()
         CodeFormatter.ParseAsync(filename, SourceOrigin.SourceString s, parsingOpts, checker)
 
-
     let typeNameMatches (attributeType: Type) (attrib: SynAttribute) =
         match attrib.TypeName with
         | LongIdentWithDots(ident, _range) ->

--- a/src/Myriad.Core/Types.fs
+++ b/src/Myriad.Core/Types.fs
@@ -9,4 +9,4 @@ type MyriadGeneratorAttribute(name: string) =
     member __.Name = name
 
 type IMyriadGenerator =
-    abstract member Generate: namespace': string * ast:ParsedInput -> FsAst.AstRcd.SynModuleOrNamespaceRcd
+    abstract member Generate: namespace': string * ast: ParsedInput -> FsAst.AstRcd.SynModuleOrNamespaceRcd

--- a/src/Myriad.Plugins/Attribute.fs
+++ b/src/Myriad.Plugins/Attribute.fs
@@ -10,3 +10,7 @@ module Generator =
 
     type DuCasesAttribute() =
         inherit Attribute()
+
+    /// Instructs to generate lenses for each property of the record
+    type LensesAttribute() =
+        inherit Attribute()

--- a/src/Myriad.Plugins/Attribute.fs
+++ b/src/Myriad.Plugins/Attribute.fs
@@ -2,7 +2,6 @@ namespace Myriad.Plugins
 
 open System
 
-
 [<RequireQualifiedAccess>]
 module Generator =
     type FieldsAttribute() =
@@ -12,5 +11,9 @@ module Generator =
         inherit Attribute()
 
     /// Instructs to generate lenses for each property of the record
-    type LensesAttribute() =
+    type LensesAttribute(wrapperName : string) =
         inherit Attribute()
+        let mutable _wrapperName = wrapperName
+        member this.WrapperName = _wrapperName
+        new () = LensesAttribute(null : string)
+        new (``type``: Type) = LensesAttribute(``type``.Name)

--- a/src/Myriad.Plugins/DUCasesGenerator.fs
+++ b/src/Myriad.Plugins/DUCasesGenerator.fs
@@ -1,6 +1,5 @@
 namespace Myriad.Plugins
 
-open System
 open FSharp.Compiler.SyntaxTree
 open FsAst
 open Myriad.Core
@@ -28,7 +27,7 @@ module internal CreateDUModule =
                 |> List.map (fun c ->
                     let case = c.ToRcd
                     let indent = LongIdentWithDots.CreateString (case.Id.idText)
-                    let args = if case.HasFields then [SynPatRcd.CreateWild ] else []
+                    let args = if case.HasFields then [SynPatRcd.CreateWild] else []
                     let p = SynPatRcd.CreateLongIdent(indent, args)
                     let rhs =
                        SynExpr.Const(SynConst.CreateString case.Id.idText, range.Zero)
@@ -109,7 +108,7 @@ module internal CreateDUModule =
                 |> List.mapi (fun i c ->
                     let case = c.ToRcd
                     let indent = LongIdentWithDots.CreateString (case.Id.idText)
-                    let args = if case.HasFields then [SynPatRcd.CreateWild ] else []
+                    let args = if case.HasFields then [SynPatRcd.CreateWild] else []
                     let p = SynPatRcd.CreateLongIdent(indent, args)
                     let rhs =
                        SynExpr.Const(SynConst.Int32 i, range.Zero)
@@ -143,7 +142,7 @@ module internal CreateDUModule =
             let expr =
                 let matchCase =
                     let indent = LongIdentWithDots.CreateString (case.Id.idText)
-                    let args = if case.HasFields then [SynPatRcd.CreateWild ] else []
+                    let args = if case.HasFields then [SynPatRcd.CreateWild] else []
                     let p = SynPatRcd.CreateLongIdent(indent, args)
 
                     let rhs = SynExpr.Const (SynConst.Bool true, range.Zero)
@@ -195,9 +194,9 @@ type DUCasesGenerator() =
 
     interface IMyriadGenerator with
         member __.Generate(namespace', ast: ParsedInput) =
-            let namespaceAndrecords = Ast.extractDU ast
+            let namespaceAndRecords = Ast.extractDU ast
             let modules =
-                namespaceAndrecords
+                namespaceAndRecords
                 |> List.collect (fun (ns, dus) ->
                                     dus
                                     |> List.filter (Ast.hasAttribute<Generator.DuCasesAttribute>)

--- a/src/Myriad.Plugins/FieldsGenerator.fs
+++ b/src/Myriad.Plugins/FieldsGenerator.fs
@@ -1,6 +1,5 @@
 ﻿namespace Myriad.Plugins
 
-open System
 open FSharp.Compiler.SyntaxTree
 open FsAst
 open Myriad.Core
@@ -20,7 +19,7 @@ module internal Create =
         let pattern =
             let name = LongIdentWithDots.CreateString fieldName.idText
             let arg =
-                let named = SynPatRcd.CreateNamed(Ident.Create varName, SynPatRcd.CreateWild )
+                let named = SynPatRcd.CreateNamed(Ident.Create varName, SynPatRcd.CreateWild)
                 SynPatRcd.CreateTyped(named, recordType)
                 |> SynPatRcd.CreateParen
 
@@ -50,9 +49,9 @@ module internal Create =
         let pattern =
             let arguments =
                 fields
-                |> List.map (fun f ->let field = f.ToRcd
-                                     let name = SynPatRcd.CreateNamed(field.Id.Value, SynPatRcd.CreateWild)
-                                     SynPatRcd.CreateTyped(name, field.Type) |> SynPatRcd.CreateParen)
+                |> List.map (fun f -> let field = f.ToRcd
+                                      let name = SynPatRcd.CreateNamed(field.Id.Value, SynPatRcd.CreateWild)
+                                      SynPatRcd.CreateTyped(name, field.Type) |> SynPatRcd.CreateParen)
 
             SynPatRcd.CreateLongIdent(varIdent, arguments)
 
@@ -171,9 +170,9 @@ type FieldsGenerator() =
 
     interface IMyriadGenerator with
         member __.Generate(namespace', ast: ParsedInput) =
-            let namespaceAndrecords = Ast.extractRecords ast
+            let namespaceAndRecords = Ast.extractRecords ast
             let modules =
-                namespaceAndrecords
+                namespaceAndRecords
                 |> List.collect (fun (ns, records) ->
                                     records
                                     |> List.filter (Ast.hasAttribute<Generator.FieldsAttribute>)

--- a/src/Myriad.Plugins/LensesGenerator.fs
+++ b/src/Myriad.Plugins/LensesGenerator.fs
@@ -244,5 +244,4 @@ type LensesGenerator() =
                         IsRecursive = true
                         Declarations = recordsModules @ duModules }
 
-            // todo brinchuk support single-case DU
             namespaceOrModule

--- a/src/Myriad.Plugins/LensesGenerator.fs
+++ b/src/Myriad.Plugins/LensesGenerator.fs
@@ -85,7 +85,7 @@ module internal CreateLenses =
 
         let getterName = Ident("getter", range.Zero)
         let pattern =
-            SynPatRcd.CreateLongIdent(LongIdentWithDots.CreateString "_Lens", [])
+            SynPatRcd.CreateLongIdent(LongIdentWithDots.CreateString "Lens'", [])
 
         let matchCaseIdentParts =
             if requiresQualifiedAccess then

--- a/src/Myriad.Plugins/LensesGenerator.fs
+++ b/src/Myriad.Plugins/LensesGenerator.fs
@@ -1,0 +1,116 @@
+﻿namespace Myriad.Plugins
+
+open FSharp.Compiler.SyntaxTree
+open FsAst
+open Myriad.Core
+open FSharp.Compiler.Range
+
+module internal CreateLenses =
+
+    let createFieldMap (parent: LongIdent) (field: SynField) =
+        let r = range0
+        
+        let field = field.ToRcd
+        let fieldName = match field.Id with None -> failwith "no field name" | Some f -> f
+
+        let recordType =
+            LongIdentWithDots.Create (parent |> List.map (fun i -> i.idText))
+            |> SynType.CreateLongIdent
+
+        let pattern =
+            let name = LongIdentWithDots.CreateString fieldName.idText
+            SynPatRcd.CreateLongIdent(name, [])
+
+        let expr =
+            let srcVarName = "x"
+            let srcIdent = Ident.Create srcVarName
+
+            // x.Property
+            let getBody = LongIdentWithDots.Create [srcVarName; fieldName.idText]
+            let recordArg = SynSimplePat.Typed(SynSimplePat.Id (srcIdent, None, false, false, false, r), recordType, r)
+            // (x : Record)
+            let getArgs = SynSimplePats.SimplePats ([recordArg], r)
+            // fun (x : Record) -> x.Property
+            let get = SynExpr.Lambda (false, false, getArgs, SynExpr.CreateLongIdent(false, getBody, None), r)
+
+            let valueIdent = Ident.Create "value"
+            let valuePattern = SynSimplePat.Typed(SynSimplePat.Id (valueIdent, None, false, false, false, r), field.Type, r)
+            // (value : PropertyType)
+            let valueArgPatterns = SynSimplePats.SimplePats ([valuePattern], r)
+            let copySrc = SynExpr.CreateLongIdent(false, LongIdentWithDots.Create [srcVarName], None)
+            let recordToUpdateName : RecordFieldName = (LongIdentWithDots.CreateString fieldName.idText, true)
+            // { x with Property = value }
+            let recordUpdate =
+                SynExpr.CreateRecordUpdate (copySrc, [(recordToUpdateName, SynExpr.Ident valueIdent |> Some, None)])
+
+            // (value : PropertyType) -> { x with Property = value }
+            let innerLambdaWithValue =
+                SynExpr.Lambda (false, true, valueArgPatterns, recordUpdate, r)
+
+            // fun (x : Record) (value : PropertyType) -> { x with Property = value }
+            let set =
+                SynExpr.Lambda (false, true, getArgs, innerLambdaWithValue, r)
+
+            SynExpr.CreateTuple [
+                get
+                set
+            ]
+
+        let valData =
+            let valInfo = SynValInfo.SynValInfo([[]], SynArgInfo.Empty)
+            SynValData.SynValData(None, valInfo, None)
+
+        SynModuleDecl.CreateLet [{SynBindingRcd.Let with
+                                    Pattern = pattern
+                                    Expr = expr
+                                    ValData = valData }]
+
+    let private updateLast list updater =
+        let folder item state =
+            match state with
+            | [] -> [updater item]
+            | l -> item :: l
+
+        List.foldBack folder list []
+
+    let createRecordModule (namespaceId: LongIdent) (typeDefn: SynTypeDefn) =
+        let (TypeDefn(synComponentInfo, synTypeDefnRepr, _members, _range)) = typeDefn
+        let (ComponentInfo(_attributes, _typeParams, _constraints, recordId, _doc, _preferPostfix, _access, _range)) = synComponentInfo
+
+        match synTypeDefnRepr with
+        | SynTypeDefnRepr.Simple(SynTypeDefnSimpleRepr.Record(_accessibility, recordFields, _recordRange), _range) ->
+
+            let openParent = SynModuleDecl.CreateOpen (LongIdentWithDots.Create (namespaceId |> List.map (fun ident -> ident.idText)))
+
+            let fieldMaps = recordFields |> List.map (createFieldMap recordId)
+
+            let declarations = [
+                yield openParent
+                yield! fieldMaps ]
+
+            let ident = updateLast recordId (fun i -> Ident.Create (sprintf "%sLenses" i.idText))
+
+            let info = SynComponentInfoRcd.Create ident
+            SynModuleDecl.CreateNestedModule(info, declarations)
+        | _ -> failwithf "Not a record type"
+
+[<MyriadGenerator("lenses")>]
+type LensesGenerator() =
+
+    interface IMyriadGenerator with
+        member __.Generate(namespace', ast: ParsedInput) =
+            let namespaceAndRecords = Ast.extractRecords ast
+            let modules =
+                namespaceAndRecords
+                |> List.collect (fun (ns, records) ->
+                                    records
+                                    |> List.filter (Ast.hasAttribute<Generator.LensesAttribute>)
+                                    |> List.map (CreateLenses.createRecordModule ns))
+
+            let namespaceOrModule =
+                {SynModuleOrNamespaceRcd.CreateNamespace(Ident.CreateLong namespace')
+                    with
+                        IsRecursive = true
+                        Declarations = modules }
+
+            namespaceOrModule

--- a/src/Myriad.Plugins/Myriad.Plugins.fsproj
+++ b/src/Myriad.Plugins/Myriad.Plugins.fsproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attribute.fs" />
+    <Compile Include="LensesGenerator.fs" />
     <Compile Include="FieldsGenerator.fs" />
     <Compile Include="DUCasesGenerator.fs" />
   </ItemGroup>

--- a/test/Myriad.IntegrationPluginTests/Input.fs
+++ b/test/Myriad.IntegrationPluginTests/Input.fs
@@ -2,8 +2,6 @@
 
 open Myriad.Plugins
 
-type Lens<'r, 't> = Lens of (('r -> 't) * ('r -> 't -> 'r))
-
 [<Generator.Fields>]
 [<Generator.Lenses>]
 type Test1 =
@@ -52,6 +50,18 @@ module ModuleWithDUs =
     [<Generator.Lenses>]
     [<RequireQualifiedAccess>]
     type Module_FullyQualifiedDU = FullyQualifiedCase of int
+
+[<Generator.Lenses("Lens")>]
+type Address = {
+    Street : string
+    HouseNumber : int
+}
+
+[<Generator.Lenses("Lens")>]
+type Person = {
+    Name : string
+    Address : Address
+}
 
 [<Generator.DuCases>]
 type Currency =

--- a/test/Myriad.IntegrationPluginTests/Input.fs
+++ b/test/Myriad.IntegrationPluginTests/Input.fs
@@ -49,12 +49,14 @@ module ModuleWithDUs =
     [<Generator.Lenses("Example.Lens")>]
     type Module_WrappedSingleCaseDU = SingleWrapped of int
 
+    [<Generator.Lenses>]
+    [<RequireQualifiedAccess>]
+    type Module_FullyQualifiedDU = FullyQualifiedCase of int
 
-
-//[<Generator.DuCases>]
-//type Currency =
-//    | CAD
-//    | PLN
-//    | EUR
-//    | USD
-//    | Custom of string
+[<Generator.DuCases>]
+type Currency =
+    | CAD
+    | PLN
+    | EUR
+    | USD
+    | Custom of string

--- a/test/Myriad.IntegrationPluginTests/Input.fs
+++ b/test/Myriad.IntegrationPluginTests/Input.fs
@@ -20,7 +20,7 @@ type Test2 =
 type Test1WithWrappedLens =
     { one: int }
 
-[<Generator.Lenses("Lens")>]
+[<Generator.Lenses("")>]
 type Test1WithEmptyWrapperName =
     { one_empty_wrapper_name: int }
 
@@ -32,10 +32,17 @@ type Test1WithWrappedLensWithTypedefof =
 type Test1WithWrappedLensWithTypeof =
     { one_typeof: Option<int> }
 
-[<Generator.DuCases>]
-type Currency =
-    | CAD
-    | PLN
-    | EUR
-    | USD
-    | Custom of string
+[<Generator.Lenses>]
+type SingleCaseDU = Single of int
+
+[<Generator.Lenses(typeof<Lens<_, _>>)>]
+type WrappedSingleCaseDU = SingleWrapped of int
+
+
+//[<Generator.DuCases>]
+//type Currency =
+//    | CAD
+//    | PLN
+//    | EUR
+//    | USD
+//    | Custom of string

--- a/test/Myriad.IntegrationPluginTests/Input.fs
+++ b/test/Myriad.IntegrationPluginTests/Input.fs
@@ -2,10 +2,35 @@
 
 open Myriad.Plugins
 
+type Lens<'r, 't> = Lens of (('r -> 't) * ('r -> 't -> 'r))
+
 [<Generator.Fields>]
 [<Generator.Lenses>]
-type Test1 = { one: int; two: string; three: float; four: float32 }
-type Test2 = { one: Test1; two: string }
+type Test1 =
+    { one: int
+      two: string
+      three: float
+      four: float32 }
+
+type Test2 =
+    { one: Test1
+      two: string }
+
+[<Generator.Lenses("Lens")>]
+type Test1WithWrappedLens =
+    { one: int }
+
+[<Generator.Lenses("Lens")>]
+type Test1WithEmptyWrapperName =
+    { one_empty_wrapper_name: int }
+
+[<Generator.Lenses(typedefof<Lens<_, _>>)>]
+type Test1WithWrappedLensWithTypedefof =
+    { one_typedefof: Option<int> }
+
+[<Generator.Lenses(typeof<Lens<_, _>>)>]
+type Test1WithWrappedLensWithTypeof =
+    { one_typeof: Option<int> }
 
 [<Generator.DuCases>]
 type Currency =

--- a/test/Myriad.IntegrationPluginTests/Input.fs
+++ b/test/Myriad.IntegrationPluginTests/Input.fs
@@ -3,6 +3,7 @@
 open Myriad.Plugins
 
 [<Generator.Fields>]
+[<Generator.Lenses>]
 type Test1 = { one: int; two: string; three: float; four: float32 }
 type Test2 = { one: Test1; two: string }
 

--- a/test/Myriad.IntegrationPluginTests/Input.fs
+++ b/test/Myriad.IntegrationPluginTests/Input.fs
@@ -17,19 +17,19 @@ type Test2 =
       two: string }
 
 [<Generator.Lenses("Lens")>]
-type Test1WithWrappedLens =
+type RecordWithWrappedLens =
     { one: int }
 
 [<Generator.Lenses("")>]
-type Test1WithEmptyWrapperName =
+type RecordWithEmptyWrapperName =
     { one_empty_wrapper_name: int }
 
 [<Generator.Lenses(typedefof<Lens<_, _>>)>]
-type Test1WithWrappedLensWithTypedefof =
+type RecordWithWrappedLensViaTypedefof =
     { one_typedefof: Option<int> }
 
 [<Generator.Lenses(typeof<Lens<_, _>>)>]
-type Test1WithWrappedLensWithTypeof =
+type RecordWithWrappedLensViaTypeof =
     { one_typeof: Option<int> }
 
 [<Generator.Lenses>]
@@ -37,6 +37,18 @@ type SingleCaseDU = Single of int
 
 [<Generator.Lenses(typeof<Lens<_, _>>)>]
 type WrappedSingleCaseDU = SingleWrapped of int
+
+[<RequireQualifiedAccess>]
+[<Generator.Lenses>]
+type FullyQualifiedDU = FullyQualified of string
+
+module ModuleWithDUs =
+    [<Generator.Lenses>]
+    type Module_SingleCaseDU = Single of int
+
+    [<Generator.Lenses("Example.Lens")>]
+    type Module_WrappedSingleCaseDU = SingleWrapped of int
+
 
 
 //[<Generator.DuCases>]

--- a/test/Myriad.IntegrationPluginTests/Lenses.fs
+++ b/test/Myriad.IntegrationPluginTests/Lenses.fs
@@ -1,0 +1,19 @@
+namespace Example
+
+type Lens<'r, 't> = Lens of (('r -> 't) * ('r -> 't -> 'r))
+
+[<AutoOpen>]
+module Lens =
+    let (<<) (Lens (get1, set1)) (Lens (get2, set2)) =
+        let set outer value =
+            let inner = get1 outer
+            let updatedInner = set2 inner value
+            let updatedOuter = set1 outer updatedInner
+            updatedOuter
+        Lens (get1 >> get2, set)
+
+    let get (Lens (get, _)) source =
+        get source
+
+    let set (Lens (_, set)) value source =
+        set source value

--- a/test/Myriad.IntegrationPluginTests/Myriad.IntegrationPluginTests.fsproj
+++ b/test/Myriad.IntegrationPluginTests/Myriad.IntegrationPluginTests.fsproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- <MyriadSdkWaitForDebugger>true</MyriadSdkWaitForDebugger> -->
+<!--     <MyriadSdkWaitForDebugger>true</MyriadSdkWaitForDebugger>-->
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Input.fs" />

--- a/test/Myriad.IntegrationPluginTests/Myriad.IntegrationPluginTests.fsproj
+++ b/test/Myriad.IntegrationPluginTests/Myriad.IntegrationPluginTests.fsproj
@@ -9,6 +9,7 @@
 <!--     <MyriadSdkWaitForDebugger>true</MyriadSdkWaitForDebugger>-->
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Lenses.fs" />
     <Compile Include="Input.fs" />
     <Compile Include="Generated.fs">
       <MyriadFile>Input.fs</MyriadFile>

--- a/test/Myriad.IntegrationPluginTests/Tests.fs
+++ b/test/Myriad.IntegrationPluginTests/Tests.fs
@@ -75,13 +75,13 @@ let tests =
 
             testList "Single-case DUs" [
                 test "Unwrapped getter" {
-                    let getter = fst Test.SingleCaseDULenses._Lens
+                    let getter = fst Test.SingleCaseDULenses.Lens'
                     let t = Single 1
 
                     Expect.equal (getter t) 1 "getter returns the value"
                 }
                 test "Unwrapped setter" {
-                    let setter = snd Test.SingleCaseDULenses._Lens
+                    let setter = snd Test.SingleCaseDULenses.Lens'
                     let t = Single 1
 
                     let updated = setter t 2
@@ -89,13 +89,13 @@ let tests =
                     Expect.equal actualValue 2 "getter returns the value"
                 }
                 test "Wrapped getter" {
-                    let (Lens (getter, _)) = Test.WrappedSingleCaseDULenses._Lens
+                    let (Lens (getter, _)) = Test.WrappedSingleCaseDULenses.Lens'
                     let t = SingleWrapped 1
 
                     Expect.equal (getter t) 1 "getter returns the value"
                 }
                 test "Wrapped setter" {
-                    let (Lens (_, setter)) = Test.WrappedSingleCaseDULenses._Lens
+                    let (Lens (_, setter)) = Test.WrappedSingleCaseDULenses.Lens'
                     let t = SingleWrapped 1
 
                     let updated = setter t 2

--- a/test/Myriad.IntegrationPluginTests/Tests.fs
+++ b/test/Myriad.IntegrationPluginTests/Tests.fs
@@ -53,14 +53,14 @@ let tests =
 
                 test "Wrapped getter" {
                     let (Lens(getter, _)) = Test.Test1WithWrappedLensLenses.one
-                    let src : Test1WithWrappedLens = { one = 1 }
+                    let src : RecordWithWrappedLens = { one = 1 }
                     let value = getter src
                     Expect.equal 1 value "getter returns the value"
                 }
 
                 test "Wrapped setter" {
                     let (Lens(_, setter)) = Test.Test1WithWrappedLensLenses.one
-                    let src : Test1WithWrappedLens = { one = 1 }
+                    let src : RecordWithWrappedLens = { one = 1 }
                     let updated = setter src 2
                     Expect.equal { one = 2 } updated "setter updates the value"
                 }

--- a/test/Myriad.IntegrationPluginTests/Tests.fs
+++ b/test/Myriad.IntegrationPluginTests/Tests.fs
@@ -49,5 +49,19 @@ let tests =
                 let updated = setter t 2
                 Expect.equal 2 updated.one "setter updates the value"
             }
+
+            test "Wrapped getter" {
+                let (Lens(getter, _)) = Test.Test1WithWrappedLensLenses.one
+                let src : Test1WithWrappedLens = { one = 1 }
+                let value = getter src
+                Expect.equal 1 value "getter returns the value"
+            }
+
+            test "Wrapped setter" {
+                let (Lens(_, setter)) = Test.Test1WithWrappedLensLenses.one
+                let src : Test1WithWrappedLens = { one = 1 }
+                let updated = setter src 2
+                Expect.equal { one = 2 } updated "setter updates the value"
+            }
         ]
     ]

--- a/test/Myriad.IntegrationPluginTests/Tests.fs
+++ b/test/Myriad.IntegrationPluginTests/Tests.fs
@@ -52,25 +52,26 @@ let tests =
                 }
 
                 test "Wrapped getter" {
-                    let (Lens(getter, _)) = Test.Test1WithWrappedLensLenses.one
+                    let (Lens(getter, _)) = Test.RecordWithWrappedLensLenses.one
                     let src : RecordWithWrappedLens = { one = 1 }
                     let value = getter src
                     Expect.equal 1 value "getter returns the value"
                 }
 
                 test "Wrapped setter" {
-                    let (Lens(_, setter)) = Test.Test1WithWrappedLensLenses.one
+                    let (Lens(_, setter)) = Test.RecordWithWrappedLensLenses.one
                     let src : RecordWithWrappedLens = { one = 1 }
                     let updated = setter src 2
                     Expect.equal { one = 2 } updated "setter updates the value"
                 }
 
                 test "Empty wrapper name" {
-                    let (getter, _) = Test.Test1WithEmptyWrapperNameLenses.one_empty_wrapper_name
+                    let (getter, _) = Test.RecordWithEmptyWrapperNameLenses.one_empty_wrapper_name
                     let src = { one_empty_wrapper_name = 1 }
                     Expect.equal 1 (getter src) "getter returns the value"
                 }
             ]
+
             testList "Single-case DUs" [
                 test "Unwrapped getter" {
                     let getter = fst Test.SingleCaseDULenses._Lens

--- a/test/Myriad.IntegrationPluginTests/Tests.fs
+++ b/test/Myriad.IntegrationPluginTests/Tests.fs
@@ -1,6 +1,5 @@
 module Tests
 
-open System
 open Expecto
 open Example
 
@@ -37,5 +36,18 @@ let tests =
             Expect.equal z 1 "generated getters should be ok"
         }
 
+        testList "Lenses" [
+            let t = Test.Test1.create 1 "2" 3. (float32 4)
 
+            test "Getter" {
+                let getter = fst Test.Test1Lenses.one
+                Expect.equal 1 (getter t) "getter returns the value"
+            }
+
+            test "Setter" {
+                let setter = snd Test.Test1Lenses.one
+                let updated = setter t 2
+                Expect.equal 2 updated.one "setter updates the value"
+            }
+        ]
     ]

--- a/test/Myriad.IntegrationPluginTests/Tests.fs
+++ b/test/Myriad.IntegrationPluginTests/Tests.fs
@@ -2,6 +2,7 @@ module Tests
 
 open Expecto
 open Example
+open Test
 
 let tests =
     testList "basic tests" [
@@ -102,5 +103,25 @@ let tests =
                     Expect.equal actualValue 2 "getter returns the value"
                 }
             ]
+
+            test "Lens composition" {
+                let houseNumberLens = PersonLenses.Address << AddressLenses.HouseNumber
+                let person = {
+                    Name = "Sherlock"
+                    Address = {
+                        Street = "Baker st."
+                        HouseNumber = 221
+                    }
+                }
+
+                let houseNumber = Lens.get houseNumberLens person
+
+                Expect.equal houseNumber 221 "Gets correct house number"
+
+                let updatedPerson = person |> Lens.set houseNumberLens 1
+                let updatedHouseNumber = Lens.get houseNumberLens updatedPerson
+
+                Expect.equal updatedHouseNumber 1 "Gets updated value"
+            }
         ]
     ]

--- a/test/Myriad.IntegrationPluginTests/Tests.fs
+++ b/test/Myriad.IntegrationPluginTests/Tests.fs
@@ -37,31 +37,69 @@ let tests =
         }
 
         testList "Lenses" [
-            let t = Test.Test1.create 1 "2" 3. (float32 4)
+            testList "Records" [
+                let t = Test.Test1.create 1 "2" 3. (float32 4)
 
-            test "Getter" {
-                let getter = fst Test.Test1Lenses.one
-                Expect.equal 1 (getter t) "getter returns the value"
-            }
+                test "Getter" {
+                    let getter = fst Test.Test1Lenses.one
+                    Expect.equal 1 (getter t) "getter returns the value"
+                }
 
-            test "Setter" {
-                let setter = snd Test.Test1Lenses.one
-                let updated = setter t 2
-                Expect.equal 2 updated.one "setter updates the value"
-            }
+                test "Setter" {
+                    let setter = snd Test.Test1Lenses.one
+                    let updated = setter t 2
+                    Expect.equal 2 updated.one "setter updates the value"
+                }
 
-            test "Wrapped getter" {
-                let (Lens(getter, _)) = Test.Test1WithWrappedLensLenses.one
-                let src : Test1WithWrappedLens = { one = 1 }
-                let value = getter src
-                Expect.equal 1 value "getter returns the value"
-            }
+                test "Wrapped getter" {
+                    let (Lens(getter, _)) = Test.Test1WithWrappedLensLenses.one
+                    let src : Test1WithWrappedLens = { one = 1 }
+                    let value = getter src
+                    Expect.equal 1 value "getter returns the value"
+                }
 
-            test "Wrapped setter" {
-                let (Lens(_, setter)) = Test.Test1WithWrappedLensLenses.one
-                let src : Test1WithWrappedLens = { one = 1 }
-                let updated = setter src 2
-                Expect.equal { one = 2 } updated "setter updates the value"
-            }
+                test "Wrapped setter" {
+                    let (Lens(_, setter)) = Test.Test1WithWrappedLensLenses.one
+                    let src : Test1WithWrappedLens = { one = 1 }
+                    let updated = setter src 2
+                    Expect.equal { one = 2 } updated "setter updates the value"
+                }
+
+                test "Empty wrapper name" {
+                    let (getter, _) = Test.Test1WithEmptyWrapperNameLenses.one_empty_wrapper_name
+                    let src = { one_empty_wrapper_name = 1 }
+                    Expect.equal 1 (getter src) "getter returns the value"
+                }
+            ]
+            testList "Single-case DUs" [
+                test "Unwrapped getter" {
+                    let getter = fst Test.SingleCaseDULenses._Lens
+                    let t = Single 1
+
+                    Expect.equal (getter t) 1 "getter returns the value"
+                }
+                test "Unwrapped setter" {
+                    let setter = snd Test.SingleCaseDULenses._Lens
+                    let t = Single 1
+
+                    let updated = setter t 2
+                    let (Single actualValue) = updated
+                    Expect.equal actualValue 2 "getter returns the value"
+                }
+                test "Wrapped getter" {
+                    let (Lens (getter, _)) = Test.WrappedSingleCaseDULenses._Lens
+                    let t = SingleWrapped 1
+
+                    Expect.equal (getter t) 1 "getter returns the value"
+                }
+                test "Wrapped setter" {
+                    let (Lens (_, setter)) = Test.WrappedSingleCaseDULenses._Lens
+                    let t = SingleWrapped 1
+
+                    let updated = setter t 2
+                    let (SingleWrapped actualValue) = updated
+                    Expect.equal actualValue 2 "getter returns the value"
+                }
+            ]
         ]
     ]


### PR DESCRIPTION
For the type

```fsharp
type Test1 =
    { one: int
      two: string
      three: float
      four: float32 }
```

generates these pairs of getters and setters:

```fsharp
module Test1Lenses =
    open Example

    let one =
        (fun (x: Test1) -> x.one), (fun (x: Test1) (value: int) -> { x with one = value })

    let two =
        (fun (x: Test1) -> x.two), (fun (x: Test1) (value: string) -> { x with two = value })

    let three =
        (fun (x: Test1) -> x.three), (fun (x: Test1) (value: float) -> { x with three = value })

    let four =
        (fun (x: Test1) -> x.four), (fun (x: Test1) (value: float32) -> { x with four = value })
```

For a single-case DU
```fsharp
type SingleCaseDU = Single of int
```

generates

```fsharp
module SingleCaseDULenses =
    open Example

    let _Lens =
        let getter (x: SingleCaseDU) =
            match x with
            | Single x -> x

        getter, (fun (_: SingleCaseDU) (value: int) -> Single value)
```

Also wraps generated lenses in a user-provided single-case DU wrapper:

```fsharp
module RecordWithWrappedLensViaTypeofLenses =
    open Example

    let one_typeof =
        Lens
            ((fun (x: RecordWithWrappedLensViaTypeof) -> x.one_typeof),
             (fun (x: RecordWithWrappedLensViaTypeof) (value: Option<int>) -> { x with one_typeof = value }))
```

where `Lens` is defined like this:

```fsharp
type Lens<'r, 't> = Lens of (('r -> 't) * ('r -> 't -> 'r))
```

The name of the wrapper can be specified in several ways:
```fsharp
[<Generator.Lenses("Lens")>]
[<Generator.Lenses(typedefof<Lens<_, _>>)>]
[<Generator.Lenses(typeof<Lens<_, _>>)>]

// for a wrapper in a namespace different from a DU's one:
[<Generator.Lenses("Example.Lens")>]
```