### PR TITLE
Add rollForward policy to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.201"
+    "version": "3.1.201",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Without a rollForwardPolicy the developer has to have the EXACT version specified in the global.json.
Especially if you are not in a devcontainer, I think this is not that easy and not necessary.

Therefore I added the rollForward attribute to global.json, which also allows to use newer versions of the SDK instead of only the exact version. latestFeature is just a guess what could work nicely and could be changed.

I read about that here:
https://andrewlock.net/exploring-the-new-rollforward-and-allowprerelease-settings-in-global-json/
and
https://docs.microsoft.com/de-de/dotnet/core/tools/global-json?tabs=netcore3x