### PR TITLE
Don't print unknown AST fragments

### DIFF
--- a/src/Myriad.Core/Ast.fs
+++ b/src/Myriad.Core/Ast.fs
@@ -53,7 +53,7 @@ module Ast =
                     | SynModuleDecl.NestedModule(ComponentInfo(attribs, typeParams, constraints, longId, xmlDoc, preferPostfix, accessibility, range), isRec, decls, _, _range) ->
                         let combined = longId |> List.append ns
                         yield! (extractTypes decls combined)
-                    | other -> printfn "other: %A" other
+                    | other -> ()
             ]
 
         [   match ast with


### PR DESCRIPTION
This was making my build logs kinda noisy :)