### PR TITLE
Camel Case the parameters of the function to create records

### DIFF
--- a/src/Myriad.Plugins/FieldsGenerator.fs
+++ b/src/Myriad.Plugins/FieldsGenerator.fs
@@ -46,11 +46,14 @@ module internal Create =
             LongIdentWithDots.Create (parent |> List.map (fun i -> i.idText))
             |> SynType.CreateLongIdent
 
+        let camelCaseIdent (ident: Ident) =
+            Ident.Create(ident.idText.Substring(0, 1).ToLowerInvariant() + ident.idText.Substring(1))
+
         let pattern =
             let arguments =
                 fields
                 |> List.map (fun f -> let field = f.ToRcd
-                                      let name = SynPatRcd.CreateNamed(field.Id.Value, SynPatRcd.CreateWild)
+                                      let name = SynPatRcd.CreateNamed(camelCaseIdent field.Id.Value, SynPatRcd.CreateWild)
                                       SynPatRcd.CreateTyped(name, field.Type) |> SynPatRcd.CreateParen)
 
             SynPatRcd.CreateLongIdent(varIdent, arguments)
@@ -58,11 +61,11 @@ module internal Create =
         let expr =
             let fields =
                 fields
-                |> List.map (fun f ->   let field = f.ToRcd
-                                        let fieldIdent = match field.Id with None -> failwith "no field name" | Some f -> f
-                                        let name = LongIdentWithDots.Create([fieldIdent.idText])
-                                        let ident = SynExpr.CreateIdent fieldIdent
-                                        RecordFieldName(name, true), Some ident, None)
+                |> List.map (fun f -> let field = f.ToRcd
+                                      let fieldIdent = match field.Id with None -> failwith "no field name" | Some f -> f
+                                      let name = LongIdentWithDots.Create([fieldIdent.idText])
+                                      let ident = SynExpr.CreateIdent(camelCaseIdent fieldIdent)
+                                      RecordFieldName(name, true), Some ident, None)
 
             let newRecord = SynExpr.Record(None, None, fields, range.Zero )
             SynExpr.CreateTyped(newRecord, recordType)


### PR DESCRIPTION
My types:
![image](https://user-images.githubusercontent.com/688618/96060218-47dc3900-0e66-11eb-8eb6-888d33df3b0b.png)

The generated code:
![image](https://user-images.githubusercontent.com/688618/96060221-4ca0ed00-0e66-11eb-93e9-46e0675f16b1.png)

The error:
(Isn't this supposed to work? F# compiler bug?)
![image](https://user-images.githubusercontent.com/688618/96060257-60e4ea00-0e66-11eb-9519-fb88afa35d59.png)

After the changes of this PR:
![image](https://user-images.githubusercontent.com/688618/96060279-6cd0ac00-0e66-11eb-8f9f-73da1096147e.png)

I don't know if this breaks something else or the implementation is not good, but feel free to change it. Thanks!
