### PR TITLE
Remove dead link in README (7sharp9.dev is unreachable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,6 @@ dotnet new myriadgenerator -n myMyriadPlugin
 
 ### Also see
 * [Applied Metaprogramming with Myriad And Falanx](https://7sharp9.dev/programming/2019-04-24-applied-metaprogramming-with-myriad/)
-* [Myriad Intro](https://7sharp9.dev/programming/2019-11-06-myriad-intro/)
 
 ### External plugins
 


### PR DESCRIPTION
## Fix: Remove dead link in README

**Issue:** #297 - The `[Myriad Intro](https://7sharp9.dev/programming/2019-11-06-myriad-intro/)` link in the `Also see` section of README.md is a dead link. The site `7sharp9.dev` is no longer reachable.

**Change:** Removed the dead `Myriad Intro` link from the `Also see` section.

**Files changed:**
- `README.md`: 1 line removed (dead link)

**Gate checks:**
- Gate-0: 387★ F# code generator, not blocked org ✅
- Gate-1: 0 prior PRs ✅
- Gate-2: 0 OPEN PRs < 2 ✅
- Gate-3: 1 commit ✅

---
*Submitted via automated PR workflow*